### PR TITLE
Bugfix/ unregister broadcastReceiver

### DIFF
--- a/app/src/main/java/wavetechstudio/sms/retriever/apimaster/MainActivity.java
+++ b/app/src/main/java/wavetechstudio/sms/retriever/apimaster/MainActivity.java
@@ -76,7 +76,8 @@ public class MainActivity extends AppCompatActivity implements
         showToast("OTP Received: " + otp);
 
         if (smsReceiver != null) {
-            LocalBroadcastManager.getInstance(this).unregisterReceiver(smsReceiver);
+            unregisterReceiver(smsReceiver);
+            smsReceiver = null;
         }
     }
 
@@ -95,7 +96,7 @@ public class MainActivity extends AppCompatActivity implements
     protected void onDestroy() {
         super.onDestroy();
         if (smsReceiver != null) {
-            LocalBroadcastManager.getInstance(this).unregisterReceiver(smsReceiver);
+            unregisterReceiver(smsReceiver);
         }
     }
 


### PR DESCRIPTION
Hi, 
This is a nice sample code, I found a bug for the unregistering broadcast receiver.
You should use LocalBroadcastManager when the broadcast receiver is registered by LocalBroadcastManager.

Have a nice day,
thanks